### PR TITLE
Add Docker server, map pan/zoom, auto-load from save file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.claude/
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .claude/
 CLAUDE.md
+server/.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .claude/
 CLAUDE.md
 server/.env
+server/style-example.html

--- a/README.md
+++ b/README.md
@@ -4,24 +4,19 @@
 
 I was sitting around 600 Koroks found and was having a really difficult time following any sort of checklist to find the rest since I would need to check off all 600 that I found before it would be useful for me.
 
-So, I slapped this together to parse a save file from the game to show only the ones that I have yet to find. I also added Locations on there for good measure as they play into the percentage on the map as well.
+So, I slapped this together to parse a Cemu save file to show only the Koroks and Locations that I have yet to find. As you find them in-game, the map automatically refreshes to reflect your progress.
 
 As you find Koroks/Locations, clicking on them will remove them from the map.
 
-Once a save file has been loaded, the parsed data is saved into your web browser, so you can close the window whenever you like without losing anything. It will also remember any markers that you have removed.
-
-If you would rather use this as a checklist _without_ loading a save file, that option is available as well.
-
 Thank you @marcrobledo for the [save game editors](https://github.com/marcrobledo/savegame-editors) much of this code is based off of and @MrCheeze for the their [waypoint map](https://github.com/MrCheeze/botw-waypoint-map) which I modified to get the map markers I needed as well as all of their [datamining research](https://github.com/MrCheeze/botw-tools).
 
-## Docker Setup (Server Mode)
+## Docker Setup
 
-This application can run as a Docker container that automatically loads the game save file and monitors for changes.
+This application runs as a Docker container that automatically reads your Cemu save file and monitors it for changes, refreshing the map whenever you save in-game.
 
 ### Requirements
 
-- Docker
-- Docker Compose
+- Docker and Docker Compose running on the same machine as your Cemu save file (or with network access to it)
 
 ### Setup
 
@@ -49,11 +44,6 @@ This application can run as a Docker container that automatically loads the game
 
 ### How It Works
 
-- The server automatically loads the game save file from the mounted data directory
+- The server reads your Cemu save file from the path defined in `server/.env`
 - The save file is monitored for changes every 10 seconds
-- When the save file is updated (e.g., after playing the game), the page automatically refreshes to show updated data
-- No manual drag-and-drop or file selection required
-
-### Data Directory
-
-The save file path is configured in `server/docker-compose.yml`. By default, it mounts the Cemu save directory to `/app/data` inside the container.
+- When the save file is updated after playing, the page automatically refreshes to show your latest progress

--- a/README.md
+++ b/README.md
@@ -25,7 +25,19 @@ This application can run as a Docker container that automatically loads the game
 
 ### Setup
 
-1. Edit `server/docker-compose.yml` to update the volume mount path if your Cemu save file is in a different location.
+1. Create a `server/.env` file to configure your Cemu save file path.
+
+   **If running Docker from WSL (Linux-style path):**
+   ```
+   SAVE_PATH=/mnt/c/Users/YourWindowsUsername/AppData/Roaming/Cemu/mlc01/usr/save/00050000/101c9400/user/80000001/0
+   ```
+
+   **If running Docker from Windows (Command Prompt or PowerShell):**
+   ```
+   SAVE_PATH=C:/Users/YourWindowsUsername/AppData/Roaming/Cemu/mlc01/usr/save/00050000/101c9400/user/80000001/0
+   ```
+
+   Replace `YourWindowsUsername` with your Windows username. The save folder ID (`80000001`) may also differ — check your Cemu save directory if unsure.
 
 2. Build and start the container:
    ```bash

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ This application runs as a Docker container that automatically reads your Cemu s
    docker compose up -d --build
    ```
 
-3. Open http://localhost:3000 in your browser.
+3. Open the viewer in your browser:
+   - From the same machine: http://localhost:3000
+   - From another device on your network: `http://<docker-host-ip>:3000` (e.g. `http://192.168.1.100:3000`)
 
 ### How It Works
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Because there _really_ needed to be 900 of them, right?
 
-I was sitting around 600 Koroks found and was having a really difficult time following any sort of checklist to find the rest since I would need to check off all 600 that I found before it would be useful for me. 
+I was sitting around 600 Koroks found and was having a really difficult time following any sort of checklist to find the rest since I would need to check off all 600 that I found before it would be useful for me.
 
 So, I slapped this together to parse a save file from the game to show only the ones that I have yet to find. I also added Locations on there for good measure as they play into the percentage on the map as well.
 
@@ -13,3 +13,35 @@ Once a save file has been loaded, the parsed data is saved into your web browser
 If you would rather use this as a checklist _without_ loading a save file, that option is available as well.
 
 Thank you @marcrobledo for the [save game editors](https://github.com/marcrobledo/savegame-editors) much of this code is based off of and @MrCheeze for the their [waypoint map](https://github.com/MrCheeze/botw-waypoint-map) which I modified to get the map markers I needed as well as all of their [datamining research](https://github.com/MrCheeze/botw-tools).
+
+## Docker Setup (Server Mode)
+
+This application can run as a Docker container that automatically loads the game save file and monitors for changes.
+
+### Requirements
+
+- Docker
+- Docker Compose
+
+### Setup
+
+1. Edit `server/docker-compose.yml` to update the volume mount path if your Cemu save file is in a different location.
+
+2. Build and start the container:
+   ```bash
+   cd server
+   docker compose up -d
+   ```
+
+3. Open http://localhost:3000 in your browser.
+
+### How It Works
+
+- The server automatically loads the game save file from the mounted data directory
+- The save file is monitored for changes every 10 seconds
+- When the save file is updated (e.g., after playing the game), the page automatically refreshes to show updated data
+- No manual drag-and-drop or file selection required
+
+### Data Directory
+
+The save file path is configured in `server/docker-compose.yml`. By default, it mounts the Cemu save directory to `/app/data` inside the container.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ I was sitting around 600 Koroks found and was having a really difficult time fol
 
 So, I slapped this together to parse a Cemu save file to show only the Koroks and Locations that I have yet to find. As you find them in-game, the map automatically refreshes to reflect your progress.
 
-As you find Koroks/Locations, clicking on them will remove them from the map.
+The toolbar tracks your running totals for:
+- **Korok seeds** (out of 900)
+- **Locations** (out of 226)
+- **Shrines** (out of 120)
+- **Towers** (out of 15)
 
-Thank you @marcrobledo for the [save game editors](https://github.com/marcrobledo/savegame-editors) much of this code is based off of and @MrCheeze for the their [waypoint map](https://github.com/MrCheeze/botw-waypoint-map) which I modified to get the map markers I needed as well as all of their [datamining research](https://github.com/MrCheeze/botw-tools).
+A server status indicator and save file timestamp in the toolbar let you know the server is reachable and when your save was last read.
+
+Thank you @marcrobledo for the [save game editors](https://github.com/marcrobledo/savegame-editors) much of this code is based off of and @MrCheeze for their [waypoint map](https://github.com/MrCheeze/botw-waypoint-map) which I modified to get the map markers I needed as well as all of their [datamining research](https://github.com/MrCheeze/botw-tools).
 
 ## Docker Setup
 
@@ -37,7 +43,7 @@ This application runs as a Docker container that automatically reads your Cemu s
 2. Build and start the container:
    ```bash
    cd server
-   docker compose up -d
+   docker compose up -d --build
    ```
 
 3. Open http://localhost:3000 in your browser.

--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -1,16 +1,39 @@
 /* Zelda BOTW Savegame editor by Marc Robledo v20170521 */
 /* minify at https://cssminifier.com/ + https://www.base64-image.de/ (sprites */
 
-/* @FONT-FACES */
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,800');
+/* @CSS VARIABLES */
+:root {
+	--botw-dark: #0a0e14;
+	--botw-darker: #05070a;
+	--botw-blue: #1a3a52;
+	--botw-cyan: #00d4ff;
+	--botw-gold: #c9a959;
+	--botw-gold-light: #e8c87a;
+	--botw-gray: #2a3a4a;
+	--botw-text: #e0e6ed;
+	--botw-text-muted: #8a9ba8;
+	--sheikah-glow: rgba(0, 212, 255, 0.3);
+}
 
-
+html,body{
+	overflow-x:hidden;
+}
 body{
-	font:15px 'Open Sans',sans-serif;
+	font:15px 'Noto Sans',sans-serif;
 	cursor:default;
-	margin:180px 0 80px;
-	background-color:#160c0c;
-	color:#f9f5da;
+	margin:100px 0 0;
+	background: linear-gradient(135deg, var(--botw-darker) 0%, var(--botw-dark) 50%, var(--botw-blue) 100%);
+	background-attachment: fixed;
+	color:var(--botw-text);
+}
+
+/* Override .wrapper constraint so the map fills the full browser width */
+#the-editor{
+	max-width:100%;
+	width:100%;
+	margin:0;
+	padding:0;
+	box-sizing:border-box;
 }
 
 /* flex box */
@@ -151,49 +174,69 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 
 /* header+toolbar+footer */
 #header{
-	color:#333;
+	color:var(--botw-text);
 	position:fixed;
-	top:-144px;
+	top:0;
 	left:0;
 	width:100%;
 	z-index:100;
-	background-color:#faf8f7;
+	background-color:var(--botw-dark);
+	border-bottom:2px solid var(--botw-gold);
+	box-shadow:0 4px 20px var(--sheikah-glow);
+}
+#header::before{
+	content:'';
+	display:block;
+	height:3px;
+	background:linear-gradient(90deg, transparent, var(--botw-cyan), var(--botw-gold), var(--botw-cyan), transparent);
+	animation:sheikahPulse 3s ease-in-out infinite;
+}
+@keyframes sheikahPulse{
+	0%,100%{opacity:0.5}
+	50%{opacity:1}
 }
 #header:after{
-	display:block;
-	position:absolute;
-	bottom:-3px;
-	left:0;
-	width:100%;
-	height:3px;
-	background-image:linear-gradient(to right, #0f0404 0%, #b99f65 40%, #b99f65 40%, #b99f65 65%, #0f0404 100%);
-
-	content:"";
+	display:none;
 }
 #toolbar{
-	padding:8px
+	padding:5px 0;
+	background:rgba(26,58,82,0.4);
+	border-top:1px solid rgba(201,169,89,0.25);
 }
 #span-version:hover{text-decoration:underline}
-#header h1{display:inline-block;font-size:110%;margin:0;flex:1;color:#333}
+#header h1{
+	display:inline-block;
+	font-size:88%;
+	margin:0;
+	flex:1;
+	color:var(--botw-gold);
+	font-family:'Cinzel',serif;
+	text-shadow:0 0 15px rgba(201,169,89,0.4);
+}
 #header h1 img{vertical-align:middle}
+#header-top .padding-vertical{padding:8px 0}
 
 
 
 .header-buttons{
-	font-size:85%
+	font-size:85%;
+	color:var(--botw-text-muted);
 }
 .header-buttons a.author{
-	color:#333;
+	color:var(--botw-gold-light);
 	text-decoration:none;
-	border-bottom:1px solid #d3cec3;
+	border-bottom:1px solid rgba(201,169,89,0.3);
+	transition:color 0.3s,border-color 0.3s,text-shadow 0.3s;
 }
 .header-buttons a.author:hover{
-	border-color:#83d8ff
+	color:var(--botw-cyan);
+	border-color:var(--botw-cyan);
+	text-shadow:0 0 10px var(--sheikah-glow);
 }
 .header-buttons a.button{
 	text-decoration:none;
 	color:white;
-	background-color:#1a415d;
+	background-color:var(--botw-blue);
 	padding:10px 20px;
 	border-radius:3px
 }
@@ -218,18 +261,41 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 
 
 
-hr{border:none;border-top:1px dotted #bbb;margin:15px 0}
+/* toolbar stat labels and values */
+#toolbar label{
+	color:var(--botw-text-muted);
+	text-transform:uppercase;
+	letter-spacing:1px;
+	font-size:0.7rem;
+	margin:0 14px;
+}
+#toolbar label span{
+	font-family:'Cinzel',serif;
+	color:var(--botw-gold);
+	font-size:0.95rem;
+	font-weight:600;
+	text-shadow:0 0 10px rgba(201,169,89,0.4);
+}
+#toolbar .text-center{
+	display:flex;
+	align-items:center;
+	justify-content:center;
+	gap:6px;
+}
+
+hr{border:none;border-top:1px dotted rgba(201,169,89,0.3);margin:15px 0}
 h3{
-	border-bottom:2px solid #888;
+	border-bottom:2px solid var(--botw-gold);
 	font-size:135%;
 	padding:10px 0;
 	text-transform:uppercase;
-	color:#b99f65
+	color:var(--botw-gold);
+	font-family:'Cinzel',serif;
 }
 
 table{width:100%}
-tbody tr:nth-child(even){background-color:#f2f2f2}
-th{background-color:#d4d4d4}
+tbody tr:nth-child(even){background-color:rgba(26,58,82,0.3)}
+th{background-color:rgba(201,169,89,0.15);color:var(--botw-gold-light)}
 
 
 
@@ -439,19 +505,19 @@ button.no-text.with-icon:before{margin-right:0px}
 
 /* MarcDragAndDrop */
 #dragzone{
-	border:4px dashed #b99f65;
-	color:#b99f65;
+	border:4px dashed var(--botw-gold);
+	color:var(--botw-gold);
 	text-align:center;
 	border-radius:8px;
 	position:relative;
 	transition:all .2s;
 	padding-bottom:20px;
-	/*font-weight:bold;*/
+	background:rgba(10,14,20,0.6);
 }
 .dragging-files #dragzone{
-	border-color:#3498db;
-	color:#3498db;
-	background-color:white
+	border-color:var(--botw-cyan);
+	color:var(--botw-cyan);
+	background-color:rgba(0,212,255,0.05);
 }
 #dragzone-message{
 	font-size:180%;
@@ -698,10 +764,37 @@ button.no-text.with-icon:before{margin-right:0px}
 /* Map viewport for pan/zoom */
 #map-viewport {
 	width: 100%;
-	height: calc(100vh - 180px);
+	height: calc(100vh - 100px);
 	overflow: hidden;
 	position: relative;
-	background: #0a0606;
+	background: radial-gradient(circle at center, rgba(26,58,82,0.4) 0%, #050a0f 100%);
+	border: 1px solid var(--botw-gray);
+	box-shadow: 0 8px 32px rgba(0,0,0,0.6), inset 0 0 60px rgba(0,0,0,0.4);
+}
+
+/* Decorative Sheikah corners on the map viewport */
+#map-viewport::before,
+#map-viewport::after{
+	content:'';
+	position:absolute;
+	width:50px;
+	height:50px;
+	border:2px solid var(--botw-gold);
+	opacity:0.5;
+	pointer-events:none;
+	z-index:10;
+}
+#map-viewport::before{
+	top:8px;
+	left:8px;
+	border-right:none;
+	border-bottom:none;
+}
+#map-viewport::after{
+	top:8px;
+	right:8px;
+	border-left:none;
+	border-bottom:none;
 }
 
 #map-viewport #map-container {

--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -186,7 +186,6 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	color:#333;
 	text-decoration:none;
 	border-bottom:1px solid #d3cec3;
-	margin-right:10px
 }
 .header-buttons a.author:hover{
 	border-color:#83d8ff

--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -15,22 +15,28 @@
 	--sheikah-glow: rgba(0, 212, 255, 0.3);
 }
 
-html,body{
-	overflow-x:hidden;
+html{
+	height:100%;
+	overflow:hidden;
 }
 body{
 	font:15px 'Noto Sans',sans-serif;
 	cursor:default;
-	margin:100px 0 0;
+	height:100%;
+	overflow:hidden;
+	margin:0;
+	padding-top:100px;
+	box-sizing:border-box;
 	background: linear-gradient(135deg, var(--botw-darker) 0%, var(--botw-dark) 50%, var(--botw-blue) 100%);
 	background-attachment: fixed;
 	color:var(--botw-text);
 }
 
-/* Override .wrapper constraint so the map fills the full browser width */
+/* Override .wrapper constraint so the map fills the full browser width and height */
 #the-editor{
 	max-width:100%;
 	width:100%;
+	height:100%;
 	margin:0;
 	padding:0;
 	box-sizing:border-box;
@@ -206,9 +212,12 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 #span-version:hover{text-decoration:underline}
 #header h1{
 	display:inline-block;
-	font-size:88%;
+	font-size:clamp(8px, 1.35vw, 13px);
 	margin:0;
 	flex:1;
+	min-width:0;
+	white-space:nowrap;
+	overflow:hidden;
 	color:var(--botw-gold);
 	font-family:'Cinzel',serif;
 	text-shadow:0 0 15px rgba(201,169,89,0.4);
@@ -219,8 +228,9 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 
 
 .header-buttons{
-	font-size:85%;
+	font-size:clamp(7px, 1vw, 11px);
 	color:var(--botw-text-muted);
+	white-space:nowrap;
 }
 .header-buttons a.author{
 	color:var(--botw-gold-light);
@@ -281,6 +291,13 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	align-items:center;
 	justify-content:center;
 	gap:6px;
+}
+#span-number-total-locations{
+	color:var(--botw-text-muted);
+	font-family:'Noto Sans',sans-serif;
+	font-size:1rem;
+	font-weight:400;
+	text-shadow:none;
 }
 
 hr{border:none;border-top:1px dotted rgba(201,169,89,0.3);margin:15px 0}
@@ -764,12 +781,13 @@ button.no-text.with-icon:before{margin-right:0px}
 /* Map viewport for pan/zoom */
 #map-viewport {
 	width: 100%;
-	height: calc(100vh - 100px);
+	height: 100%;
 	overflow: hidden;
 	position: relative;
 	background: radial-gradient(circle at center, rgba(26,58,82,0.4) 0%, #050a0f 100%);
 	border: 1px solid var(--botw-gray);
 	box-shadow: 0 8px 32px rgba(0,0,0,0.6), inset 0 0 60px rgba(0,0,0,0.4);
+	box-sizing: border-box;
 }
 
 /* Decorative Sheikah corners on the map viewport */

--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -208,6 +208,7 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	padding:5px 0;
 	background:rgba(26,58,82,0.4);
 	border-top:1px solid rgba(201,169,89,0.25);
+	position:relative;
 }
 #span-version:hover{text-decoration:underline}
 #header h1{
@@ -276,13 +277,14 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	color:var(--botw-text-muted);
 	text-transform:uppercase;
 	letter-spacing:1px;
-	font-size:0.7rem;
-	margin:0 14px;
+	font-size:clamp(6px, 0.85vw, 11px);
+	margin:0 clamp(4px, 1vw, 14px);
+	white-space:nowrap;
 }
 #toolbar label span{
 	font-family:'Cinzel',serif;
 	color:var(--botw-gold);
-	font-size:0.95rem;
+	font-size:clamp(7px, 1.1vw, 15px);
 	font-weight:600;
 	text-shadow:0 0 10px rgba(201,169,89,0.4);
 }
@@ -292,12 +294,43 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	justify-content:center;
 	gap:6px;
 }
+#server-status{
+	position:absolute;
+	right:16px;
+	top:50%;
+	transform:translateY(-50%);
+	display:flex;
+	align-items:center;
+	gap:6px;
+}
+#save-timestamp-label,
+#save-timestamp{
+	font-size:clamp(5px, 0.75vw, 10px);
+	color:var(--botw-text-muted);
+	letter-spacing:0.5px;
+	font-family:'Noto Sans',sans-serif;
+	white-space:nowrap;
+}
+.server-status-dot{
+	width:8px;
+	height:8px;
+	border-radius:50%;
+	display:inline-block;
+	flex-shrink:0;
+}
+.server-status-dot.online{
+	background-color:#4caf50;
+	box-shadow:0 0 6px rgba(76,175,80,0.8);
+}
+.server-status-dot.offline{
+	background-color:#555;
+}
 #toolbar label #span-number-total-locations,
 #toolbar label #span-number-total-shrines,
 #toolbar label #span-number-total-towers{
 	color:var(--botw-text-muted);
 	font-family:'Noto Sans',sans-serif;
-	font-size:0.95rem;
+	font-size:clamp(7px, 1.1vw, 15px);
 	font-weight:400;
 	text-shadow:none;
 }

--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -696,6 +696,19 @@ button.no-text.with-icon:before{margin-right:0px}
 	position: relative;
 }
 
+/* Map viewport for pan/zoom */
+#map-viewport {
+	width: 100%;
+	height: calc(100vh - 180px);
+	overflow: hidden;
+	position: relative;
+	background: #0a0606;
+}
+
+#map-viewport #map-container {
+	transform-origin: 0 0;
+}
+
 #path-svg {
 	width: 6000px !important;
 	height: 5000px !important;

--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -174,7 +174,7 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	padding:8px
 }
 #span-version:hover{text-decoration:underline}
-#header h1{display:none}
+#header h1{display:inline-block;font-size:110%;margin:0;flex:1;color:#333}
 #header h1 img{vertical-align:middle}
 
 

--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -292,10 +292,12 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	justify-content:center;
 	gap:6px;
 }
-#span-number-total-locations{
+#toolbar label #span-number-total-locations,
+#toolbar label #span-number-total-shrines,
+#toolbar label #span-number-total-towers{
 	color:var(--botw-text-muted);
 	font-family:'Noto Sans',sans-serif;
-	font-size:1rem;
+	font-size:0.95rem;
 	font-weight:400;
 	text-shadow:none;
 }

--- a/assets/js/savegame-editor.js
+++ b/assets/js/savegame-editor.js
@@ -113,6 +113,21 @@ MarcDragAndDrop=(function(){
 
 /* savegame load/save */
 var tempFile,hasBeenLoaded=false;
+
+// Load savegame from arraybuffer (for server-loaded files)
+function loadSavegameFromArrayBuffer(arrayBuffer, fileName) {
+    // Create MarcFile from arraybuffer directly using Object.create to avoid constructor issues
+    var marcFile = Object.create(MarcFile.prototype);
+    marcFile.fileName = 'game_data.sav';
+    marcFile.fileType = 'application/octet-stream';
+    marcFile.fileSize = arrayBuffer.byteLength;
+    marcFile.littleEndian = false;
+    marcFile._u8array = new Uint8Array(arrayBuffer);
+    marcFile._dataView = new DataView(arrayBuffer);
+    tempFile = marcFile;
+    _tempFileLoadFunction();
+}
+
 function _tempFileLoadFunction(){
 	if(SavegameEditor.checkValidSavegame()){
 		hide('dragzone');

--- a/assets/js/zelda-botw.js
+++ b/assets/js/zelda-botw.js
@@ -438,7 +438,7 @@ function removeAllWaypoints() {
 		var mapWidth = 6000;
 		var mapHeight = 5000;
 		var viewportWidth = mapViewport.clientWidth || window.innerWidth;
-		var viewportHeight = mapViewport.clientHeight || (window.innerHeight - 180);
+		var viewportHeight = mapViewport.clientHeight || (window.innerHeight);
 		var minZoom = Math.min(viewportWidth / mapWidth, viewportHeight / mapHeight);
 		var maxZoom = mapHeight / viewportHeight;
 
@@ -446,6 +446,12 @@ function removeAllWaypoints() {
 		if (mapContainer.parentElement !== mapViewport) {
 			mapViewport.appendChild(mapContainer);
 		}
+
+		// Start fully zoomed out
+		scale = minZoom;
+		panX = 0;
+		panY = 0;
+		updateTransform();
 
 		// Mouse wheel for zoom
 		mapViewport.addEventListener('wheel', function(e) {
@@ -511,7 +517,7 @@ function removeAllWaypoints() {
 		var mapWidth = 6000;
 		var mapHeight = 5000;
 		var viewportWidth = mapViewport.clientWidth || window.innerWidth;
-		var viewportHeight = mapViewport.clientHeight || (window.innerHeight - 180);
+		var viewportHeight = mapViewport.clientHeight || (window.innerHeight);
 		var scaledMapWidth = mapWidth * scale;
 		var scaledMapHeight = mapHeight * scale;
 

--- a/assets/js/zelda-botw.js
+++ b/assets/js/zelda-botw.js
@@ -5,6 +5,9 @@
 var currentEditingItem=0;
 var locationValues = {};
 
+var shrines = {};
+var towers = {};
+
 SavegameEditor={
 	Name:'The legend of Zelda: Breath of the wild',
 	Filename:'game_data.sav',
@@ -103,21 +106,31 @@ SavegameEditor={
 		locationValues.notFound = {
 			'koroks': {},
 			'locations': {},
+			'shrines': {},
+			'towers': {},
 		};
 
 		locationValues.found = {
 			'koroks': 0,
 			'locations': 0,
+			'shrines': 0,
+			'towers': 0,
 		};
 
 		// All Korok/Location Data filtered down to ones not found
 		this._notFoundLocations( koroks, 'koroks' );
 		this._notFoundLocations( locations, 'locations' );
+		this._notFoundLocations( shrines, 'shrines' );
+		this._notFoundLocations( towers, 'towers' );
 
 		window.localStorage.setItem( 'botw-unexplored-viewer', JSON.stringify( locationValues ) );
 
 		setValue( 'span-number-locations', locationValues.found.locations );
-		setValue( 'span-number-total-locations', Object.keys( locations ).length );
+		setValue( 'span-number-total-locations', 226 );
+		setValue( 'span-number-shrines', locationValues.found.shrines );
+		setValue( 'span-number-total-shrines', Object.keys( shrines ).length );
+		setValue( 'span-number-towers', locationValues.found.towers );
+		setValue( 'span-number-total-towers', Object.keys( towers ).length );
 
 		this.drawKorokPaths( locationValues.notFound.koroks );
 
@@ -243,6 +256,15 @@ function onScroll(){
 
 window.addEventListener('load',function(){
 
+	// Split warps into shrines and towers — must run after map-locations.js is loaded
+	for (var _warpHash in warps) {
+		if (warps[_warpHash].internal_name.indexOf('Location_Dungeon') === 0) {
+			shrines[_warpHash] = warps[_warpHash];
+		} else if (warps[_warpHash].internal_name.indexOf('Location_MapTower') === 0) {
+			towers[_warpHash] = warps[_warpHash];
+		}
+	}
+
 	window.addEventListener('scroll',onScroll,false);
 
 	// Auto-load save file from server
@@ -291,7 +313,11 @@ window.addEventListener('load',function(){
 
 		setValue( 'span-number-koroks', locationValues.found.koroks );
 		setValue( 'span-number-locations', locationValues.found.locations );
-		setValue( 'span-number-total-locations', Object.keys( locations ).length );
+		setValue( 'span-number-total-locations', 226 );
+		setValue( 'span-number-shrines', locationValues.found.shrines || 0 );
+		setValue( 'span-number-total-shrines', Object.keys( shrines ).length );
+		setValue( 'span-number-towers', locationValues.found.towers || 0 );
+		setValue( 'span-number-total-towers', Object.keys( towers ).length );
 
 		SavegameEditor.drawKorokPaths( locationValues.notFound.koroks );
 
@@ -313,11 +339,15 @@ window.addEventListener('load',function(){
 		locationValues.notFound = {
 			'koroks': {},
 			'locations': {},
+			'shrines': {},
+			'towers': {},
 		};
 
 		locationValues.found = {
 			'koroks': 0,
 			'locations': 0,
+			'shrines': 0,
+			'towers': 0,
 		};
 
 		for ( var hash in koroks ) {
@@ -346,7 +376,11 @@ window.addEventListener('load',function(){
 
 		setValue( 'span-number-koroks', locationValues.found.koroks );
 		setValue( 'span-number-locations', locationValues.found.locations );
-		setValue( 'span-number-total-locations', Object.keys( locations ).length );
+		setValue( 'span-number-total-locations', 226 );
+		setValue( 'span-number-shrines', locationValues.found.shrines );
+		setValue( 'span-number-total-shrines', Object.keys( shrines ).length );
+		setValue( 'span-number-towers', locationValues.found.towers );
+		setValue( 'span-number-total-towers', Object.keys( towers ).length );
 
 		SavegameEditor.drawKorokPaths( locationValues.notFound.koroks );
 

--- a/assets/js/zelda-botw.js
+++ b/assets/js/zelda-botw.js
@@ -291,18 +291,38 @@ window.addEventListener('load',function(){
 	if (typeof EventSource !== 'undefined') {
 		const eventSource = new EventSource('/api/events');
 		eventSource.onmessage = function(event) {
-			if (event.data === 'changed') {
-				// Reload the save file
+			var data;
+			try { data = JSON.parse(event.data); } catch(e) { data = { event: event.data }; }
+			if (data.event === 'connected' || data.event === 'changed') {
+				setServerOnline(true);
+				if (data.mtime) updateSaveTimestamp(data.mtime);
+			}
+			if (data.event === 'changed') {
 				loadSaveFromServer();
 			}
 		};
 		eventSource.onerror = function() {
+			setServerOnline(false);
 			// Fall back to polling
 			setInterval(loadSaveFromServer, 10000);
 		};
 	} else {
 		// Fallback for browsers without SSE support - poll every 10 seconds
 		setInterval(loadSaveFromServer, 10000);
+	}
+
+	function setServerOnline(online) {
+		var dot = document.getElementById('server-status-dot');
+		if (dot) dot.className = 'server-status-dot ' + (online ? 'online' : 'offline');
+	}
+
+	function updateSaveTimestamp(mtime) {
+		var el = document.getElementById('save-timestamp');
+		if (!el) return;
+		var d = new Date(mtime);
+		var pad = function(n) { return n < 10 ? '0' + n : n; };
+		el.textContent = pad(d.getMonth()+1) + '/' + pad(d.getDate()) + '/' + d.getFullYear()
+			+ ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds());
 	}
 
 	// If there is saved data in the browser, load that instead

--- a/assets/js/zelda-botw.js
+++ b/assets/js/zelda-botw.js
@@ -416,3 +416,130 @@ function removeAllWaypoints() {
 	} );
 
 }
+
+// Map pan and zoom functionality
+(function() {
+	var scale = 1;
+	var panX = 0;
+	var panY = 0;
+	var isPanning = false;
+	var startX = 0;
+	var startY = 0;
+	var mapContainer = null;
+	var mapViewport = null;
+
+	function initMapPanZoom() {
+		mapViewport = document.getElementById('map-viewport');
+		mapContainer = document.getElementById('map-container');
+
+		if (!mapViewport || !mapContainer) return;
+
+		// Calculate zoom limits based on map dimensions (6000x5000px) vs viewport
+		var mapWidth = 6000;
+		var mapHeight = 5000;
+		var viewportWidth = mapViewport.clientWidth || window.innerWidth;
+		var viewportHeight = mapViewport.clientHeight || (window.innerHeight - 180);
+		var minZoom = Math.min(viewportWidth / mapWidth, viewportHeight / mapHeight);
+		var maxZoom = mapHeight / viewportHeight;
+
+		// Wrap map-container in viewport if not already
+		if (mapContainer.parentElement !== mapViewport) {
+			mapViewport.appendChild(mapContainer);
+		}
+
+		// Mouse wheel for zoom
+		mapViewport.addEventListener('wheel', function(e) {
+			e.preventDefault();
+
+			var zoomFactor = 0.1;
+			var delta = e.deltaY > 0 ? -zoomFactor : zoomFactor;
+			var newScale = Math.max(minZoom, Math.min(maxZoom, scale + delta));
+
+			// Zoom toward mouse position
+			var rect = mapViewport.getBoundingClientRect();
+			var mouseX = e.clientX - rect.left;
+			var mouseY = e.clientY - rect.top;
+
+			// Calculate the point in map coordinates before zoom
+			var mapX = (mouseX - panX) / scale;
+			var mapY = (mouseY - panY) / scale;
+
+			// Calculate new pan to keep mouse position stable
+			panX = mouseX - mapX * newScale;
+			panY = mouseY - mapY * newScale;
+
+			scale = newScale;
+			updateTransform();
+		}, { passive: false });
+
+		// Middle mouse button for pan
+		mapViewport.addEventListener('mousedown', function(e) {
+			if (e.button === 1) { // Middle mouse button
+				e.preventDefault();
+				isPanning = true;
+				startX = e.clientX - panX;
+				startY = e.clientY - panY;
+				mapViewport.style.cursor = 'grabbing';
+			}
+		});
+
+		document.addEventListener('mousemove', function(e) {
+			if (isPanning) {
+				panX = e.clientX - startX;
+				panY = e.clientY - startY;
+				updateTransform();
+			}
+		});
+
+		document.addEventListener('mouseup', function(e) {
+			if (e.button === 1 && isPanning) {
+				isPanning = false;
+				mapViewport.style.cursor = 'default';
+			}
+		});
+
+		// Prevent context menu on middle click
+		mapViewport.addEventListener('contextmenu', function(e) {
+			if (e.button === 1) {
+				e.preventDefault();
+			}
+		});
+	}
+
+	function updateTransform() {
+		// Calculate bounds to prevent showing blank space around map edges
+		var mapWidth = 6000;
+		var mapHeight = 5000;
+		var viewportWidth = mapViewport.clientWidth || window.innerWidth;
+		var viewportHeight = mapViewport.clientHeight || (window.innerHeight - 180);
+		var scaledMapWidth = mapWidth * scale;
+		var scaledMapHeight = mapHeight * scale;
+
+		// Calculate min/max pan values
+		var maxPanX = 0;
+		var maxPanY = 0;
+		var minPanX = viewportWidth - scaledMapWidth;
+		var minPanY = viewportHeight - scaledMapHeight;
+
+		// If map fits entirely in viewport, center it
+		if (scaledMapWidth < viewportWidth) {
+			minPanX = maxPanX = (viewportWidth - scaledMapWidth) / 2;
+		}
+		if (scaledMapHeight < viewportHeight) {
+			minPanY = maxPanY = (viewportHeight - scaledMapHeight) / 2;
+		}
+
+		// Clamp pan values
+		panX = Math.min(maxPanX, Math.max(minPanX, panX));
+		panY = Math.min(maxPanY, Math.max(minPanY, panY));
+
+		mapContainer.style.transform = 'translate(' + panX + 'px, ' + panY + 'px) scale(' + scale + ')';
+	}
+
+	// Initialize when DOM is ready
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', initMapPanZoom);
+	} else {
+		initMapPanZoom();
+	}
+})();

--- a/assets/js/zelda-botw.js
+++ b/assets/js/zelda-botw.js
@@ -245,6 +245,44 @@ window.addEventListener('load',function(){
 
 	window.addEventListener('scroll',onScroll,false);
 
+	// Auto-load save file from server
+	function loadSaveFromServer() {
+		fetch('/data/game_data.sav')
+			.then(response => {
+				if (!response.ok) {
+					throw new Error('Save file not found');
+				}
+				return response.arrayBuffer();
+			})
+			.then(arrayBuffer => {
+				loadSavegameFromArrayBuffer(arrayBuffer, 'game_data.sav');
+			})
+			.catch(err => {
+				console.log('Waiting for save file...');
+			});
+	}
+
+	// Initial load
+	loadSaveFromServer();
+
+	// Set up Server-Sent Events for file change detection
+	if (typeof EventSource !== 'undefined') {
+		const eventSource = new EventSource('/api/events');
+		eventSource.onmessage = function(event) {
+			if (event.data === 'changed') {
+				// Reload the save file
+				loadSaveFromServer();
+			}
+		};
+		eventSource.onerror = function() {
+			// Fall back to polling
+			setInterval(loadSaveFromServer, 10000);
+		};
+	} else {
+		// Fallback for browsers without SSE support - poll every 10 seconds
+		setInterval(loadSaveFromServer, 10000);
+	}
+
 	// If there is saved data in the browser, load that instead
 	locationValuesTest = window.localStorage.getItem( 'botw-unexplored-viewer' );
 	if ( locationValuesTest ) {

--- a/index.html
+++ b/index.html
@@ -31,12 +31,20 @@
 	<div id="toolbar" class="hidden padding-vertical">
 		<div class="row wrapper">
 			<div class="twelve columns text-center"> 
-				<label for="span-number-koroks">Korok seeds 
+				<label for="span-number-koroks">Korok seeds
 					<span id="span-number-koroks"></span>/900
 				</label>
 				|
 				<label for="span-number-locations">Locations
 					<span id="span-number-locations"></span>/<span id="span-number-total-locations"></span>
+				</label>
+				|
+				<label for="span-number-shrines">Shrines
+					<span id="span-number-shrines"></span>/<span id="span-number-total-shrines"></span>
+				</label>
+				|
+				<label for="span-number-towers">Towers
+					<span id="span-number-towers"></span>/<span id="span-number-total-towers"></span>
 				</label>
 				</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
 			<h1>Unexplored Area Viewer for The Legend of Zelda: BOTW</h1>
 			<div class="six columns text-right header-buttons">
 				by <a href="/" class="author">Eric Defore</a>
-				<a href="https://github.com/d4mation/botw-unexplored-viewer/" target="_blank" class="button"><span class="sprite github"></span> See on GitHub</a>
 			</div>
 		</div>
 	</div>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 	</div>
 	<div id="toolbar" class="hidden padding-vertical">
 		<div class="row wrapper">
-			<div class="twelve columns text-center"> 
+			<div class="twelve columns text-center">
 				<label for="span-number-koroks">Korok seeds
 					<span id="span-number-koroks"></span>/900
 				</label>
@@ -46,7 +46,12 @@
 				<label for="span-number-towers">Towers
 					<span id="span-number-towers"></span>/<span id="span-number-total-towers"></span>
 				</label>
-				</div>
+			</div>
+		</div>
+		<div id="server-status">
+			<span id="save-timestamp-label">Last Updated:</span>
+			<span id="save-timestamp"></span>
+			<span id="server-status-dot" class="server-status-dot offline"></span>
 		</div>
 	</div>
 </div>

--- a/index.html
+++ b/index.html
@@ -36,9 +36,7 @@
 				<label for="span-number-locations">Locations
 					<span id="span-number-locations"></span>/<span id="span-number-total-locations"></span>
 				</label>
-				|
-				<button class="button with-icon icon3" onclick="closeFileConfirm()">Clear Data</button>
-			</div>
+				</div>
 		</div>
 	</div>
 </div>
@@ -49,16 +47,18 @@
 	<!-- DEBUG -->
 	<div id="debug"></div>
 
-	<div id="map-container">
-		<img src='./assets/images/BotW-Map.png'/>
-		<svg id="path-svg" height="5000" width="6000">
-				<defs>
-				<marker id="arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="strokeWidth" viewBox="0 0 20 20">
-					<path d="M0,0 L0,6 L9,3 Z" fill="lime" stroke="green" stroke-width="1" />
-				</marker>
-				</defs>
-			<g id="path-group" fill="none" stroke="#ffffff" stroke-width="3" marker-start="url(#arrow)""></g>
-		</svg>
+	<div id="map-viewport">
+		<div id="map-container">
+			<img src='./assets/images/BotW-Map.png'/>
+			<svg id="path-svg" height="5000" width="6000">
+					<defs>
+					<marker id="arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="strokeWidth" viewBox="0 0 20 20">
+						<path d="M0,0 L0,6 L9,3 Z" fill="lime" stroke="green" stroke-width="1" />
+					</marker>
+					</defs>
+				<g id="path-group" fill="none" stroke="#ffffff" stroke-width="3" marker-start="url(#arrow)""></g>
+			</svg>
+		</div>
 	</div>
 	
 </div>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 		<div class="row wrapper padding-vertical">
 			<h1>Unexplored Area Viewer for The Legend of Zelda: BOTW</h1>
 			<div class="six columns text-right header-buttons">
-				by <a href="/" class="author">Eric Defore</a>
+				by <a href="https://github.com/d4mation" target="_blank" class="author">Eric Defore</a> and <a href="https://github.com/Xanderphillips" target="_blank" class="author">Xanderphillips</a>
 			</div>
 		</div>
 	</div>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
 	<meta name="keywords" content="html5, savegame, save, editor, hack, exploit, wii u, zelda, breath of the wild, botw, map, korok"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
 	<link rel="shortcut icon" href="./favicon.png"/>
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Noto+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 	<link type="text/css" rel="stylesheet" href="./assets/css/zelda-botw.css" media="all"/>
 	<script type="text/javascript" src="./assets/js/savegame-editor.js"></script>
 	<script type="text/javascript" src="./assets/js/zelda-botw.js"></script>

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:18-alpine
+
+# Create app directory
+WORKDIR /app
+
+# Copy package files (from server/ directory)
+COPY server/package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy server.js (from server/ directory relative to build context)
+COPY server/server.js ./
+
+# Copy static files from parent directory
+COPY index.html ./
+COPY assets ./assets
+COPY favicon.png ./
+COPY .nojekyll ./
+
+# Create data directory
+RUN mkdir -p /app/data
+
+# Expose port 3000
+EXPOSE 3000
+
+# Start the server
+CMD ["node", "server.js"]

--- a/server/data/game_data.sav
+++ b/server/data/game_data.sav
@@ -1,0 +1,1 @@
+/mnt/c/Users/pphil/AppData/Roaming/Cemu/mlc01/usr/save/00050000/101c9400/user/80000001/0/game_data.sav

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  webserver:
+    build:
+      context: ..
+      dockerfile: server/Dockerfile
+    volumes:
+      - /mnt/c/Users/pphil/AppData/Roaming/Cemu/mlc01/usr/save/00050000/101c9400/user/80000001/0:/app/data
+    ports:
+      - "3000:3000"
+    container_name: botw-webserver
+    restart: unless-stopped

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ..
       dockerfile: server/Dockerfile
     volumes:
-      - /mnt/c/Users/pphil/AppData/Roaming/Cemu/mlc01/usr/save/00050000/101c9400/user/80000001/0:/app/data
+      - ${SAVE_PATH}:/app/data
     ports:
       - "3000:3000"
     container_name: botw-webserver

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "botw-unexplored-viewer",
+  "version": "1.0.0",
+  "description": "BOTW Unexplored Viewer Server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -34,15 +34,10 @@ app.get('/api/events', (req, res) => {
     res.setHeader('Connection', 'keep-alive');
     res.flushHeaders();
 
-    // Send initial connection message
-    res.write('data: connected\n\n');
-
-    // Store last file modification time
-    let lastMtime = null;
-
     const filePath = path.join(__dirname, DATA_PATH);
 
-    // Check file exists and get initial mtime
+    // Store last file modification time and get initial mtime
+    let lastMtime = null;
     try {
         const stats = fs.statSync(filePath);
         lastMtime = stats.mtimeMs;
@@ -50,13 +45,16 @@ app.get('/api/events', (req, res) => {
         console.error('Initial file check error:', err);
     }
 
+    // Send initial connection message with current mtime
+    res.write('data: ' + JSON.stringify({ event: 'connected', mtime: lastMtime }) + '\n\n');
+
     // Poll for file changes every 10 seconds
     const interval = setInterval(() => {
         try {
             const stats = fs.statSync(filePath);
             if (lastMtime && stats.mtimeMs !== lastMtime) {
                 lastMtime = stats.mtimeMs;
-                res.write('data: changed\n\n');
+                res.write('data: ' + JSON.stringify({ event: 'changed', mtime: stats.mtimeMs }) + '\n\n');
             } else if (!lastMtime) {
                 lastMtime = stats.mtimeMs;
             }

--- a/server/server.js
+++ b/server/server.js
@@ -71,6 +71,6 @@ app.get('/api/events', (req, res) => {
     });
 });
 
-app.listen(PORT, () => {
+app.listen(PORT, '0.0.0.0', () => {
     console.log(`Server running at http://localhost:${PORT}`);
 });

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,78 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = 3000;
+const DATA_PATH = 'data/game_data.sav';
+
+// Store file stats for change detection
+let lastFileStats = null;
+
+// Serve static files from app directory (where Dockerfile copies them)
+app.use(express.static(__dirname));
+
+// Serve the game save file
+app.get('/data/game_data.sav', (req, res) => {
+    const filePath = path.join(__dirname, DATA_PATH);
+
+    fs.readFile(filePath, (err, data) => {
+        if (err) {
+            res.status(404).send('Save file not found');
+            return;
+        }
+        res.setHeader('Content-Type', 'application/octet-stream');
+        res.setHeader('Content-Length', data.length);
+        res.send(data);
+    });
+});
+
+// Server-Sent Events endpoint for file change notifications
+app.get('/api/events', (req, res) => {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    // Send initial connection message
+    res.write('data: connected\n\n');
+
+    // Store last file modification time
+    let lastMtime = null;
+
+    const filePath = path.join(__dirname, DATA_PATH);
+
+    // Check file exists and get initial mtime
+    try {
+        const stats = fs.statSync(filePath);
+        lastMtime = stats.mtimeMs;
+    } catch (err) {
+        console.error('Initial file check error:', err);
+    }
+
+    // Poll for file changes every 10 seconds
+    const interval = setInterval(() => {
+        try {
+            const stats = fs.statSync(filePath);
+            if (lastMtime && stats.mtimeMs !== lastMtime) {
+                lastMtime = stats.mtimeMs;
+                res.write('data: changed\n\n');
+            } else if (!lastMtime) {
+                lastMtime = stats.mtimeMs;
+            }
+        } catch (err) {
+            // File might not exist yet
+            console.error('File check error:', err);
+        }
+    }, 10000);
+
+    // Clean up on close
+    req.on('close', () => {
+        clearInterval(interval);
+        res.end();
+    });
+});
+
+app.listen(PORT, () => {
+    console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary

This PR adds a self-contained Docker setup that automatically loads your Cemu save file on page load and monitors it for changes, eliminating the manual drag-and-drop workflow. It also improves the map interaction with constrained pan/zoom.

---

## Changes

### Docker server (`server/`)
- **Node.js Express server** (`server/server.js`) that serves the static frontend and exposes two endpoints:
  - `GET /data/game_data.sav` — reads and serves the binary save file from the host machine
  - `GET /api/events` — Server-Sent Events stream that polls the save file every 10 seconds and notifies the browser when it changes
- **`server/Dockerfile`** — Node 18 Alpine image; build context is repo root so all static assets are copied in
- **`server/docker-compose.yml`** — mounts the save file path from `server/.env` into the container at `/app/data/game_data.sav`
- **`server/package.json`** — single dependency: `express`

### Auto-load & live-reload (`assets/js/zelda-botw.js`, `assets/js/savegame-editor.js`)
- On page load, the app fetches `/data/game_data.sav` directly — no drag-and-drop required
- Connects to `/api/events` SSE stream; reloads the save data automatically whenever the file changes (i.e. after saving in-game)

### Map pan/zoom improvements (`assets/js/zelda-botw.js`, `assets/css/zelda-botw.css`)
- **Dynamic zoom bounds** — minimum zoom is calculated from the viewport size vs. map dimensions so you can never zoom out past the map edges
- **Pan constraints** — panning is clamped so blank space is never visible; map is centered when zoomed out enough to fit entirely in the viewport
- **CSS** — `#map-viewport` is constrained to the full viewport height minus the toolbar; overflow is hidden; `transform-origin: top left` set on `#map-container` for correct pan/zoom anchor

### Minor cleanup
- Removed the "Clear Data" button from the toolbar (no longer needed with auto-load)
- Updated `.gitignore` to exclude Claude Code config files
- Updated `README.md` with Docker setup instructions (WSL and Windows paths, `.env` config)

---

## Setup (for reviewers)

1. Create `server/.env`:
   ```
   SAVE_PATH=/path/to/your/Cemu/save/folder
   ```
2. ```bash
   cd server
   docker compose up -d --build
   ```
3. Open http://localhost:3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)